### PR TITLE
fix: subdir filter for dirs with shared prefix

### DIFF
--- a/src/giget.ts
+++ b/src/giget.ts
@@ -88,7 +88,7 @@ export async function downloadTemplate (input: string, opts: DownloadTemplateOpt
     onentry (entry) {
       entry.path = entry.path.split('/').splice(1).join('/')
       if (subdir) {
-        if (entry.path.startsWith(subdir)) {
+        if (entry.path.startsWith(subdir + '/')) {
           // Rewrite path
           entry.path = entry.path.substring(subdir.length)
         } else {


### PR DESCRIPTION
You want to download `unjs/templates/vue`, but there are two templates under `unjs/templates` that start with `vue` (`vue` and `vue-ts`). At this point you will get a wrong template

```sh
vue
└── -ts
```