### PR TITLE
docs: add sidebase template to template registry

### DIFF
--- a/templates/sidebase.json
+++ b/templates/sidebase.json
@@ -1,0 +1,6 @@
+{
+    "name": "sidebase",
+    "defaultDir": "sidebase-app",
+    "url": "https://sidebase.io",
+    "tar": "https://codeload.github.com/sidestream-tech/sidebase/tar.gz/refs/heads/main"
+}

--- a/templates/sidebase.json
+++ b/templates/sidebase.json
@@ -1,6 +1,6 @@
 {
-    "name": "sidebase",
-    "defaultDir": "sidebase-app",
+    "name": "nuxt-sidebase",
+    "defaultDir": "nuxt-sidebase-app",
     "url": "https://sidebase.io",
     "tar": "https://codeload.github.com/sidestream-tech/sidebase/tar.gz/refs/heads/main"
 }


### PR DESCRIPTION
As per:
> If you want to add your template to the built-in registry, just drop a PR to add it to the [./templates](https://github.com/unjs/giget/blob/main/templates) directory. Slugs are added on first-come first-served basis but this might change in the future.

from https://github.com/unjs/giget#template-registry I want to add [sidebase](https://github.com/sidestream-tech/sidebase) as a template, so that it can be used via the `nuxi init` command (: 

As per https://github.com/sidestream-tech/sidebase/issues/33 we will talk on twitter about this after:
- [ ] we flattened the repo + upgrade to RC10 (https://github.com/sidestream-tech/sidebase/tree/upgrade_to_rc10)
- [ ] this PR was merged
- [ ] sidebase-docs were updated
