### PR TITLE
fix: respect `XDG_CACHE_HOME` environment variable

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -2,7 +2,7 @@ import { createWriteStream, existsSync } from "node:fs";
 import { pipeline } from "node:stream";
 import { spawnSync } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
-import { homedir, platform } from "node:os";
+import { homedir } from "node:os";
 import { promisify } from "node:util";
 import { relative, resolve } from "pathe";
 import { fetch } from "node-fetch-native";
@@ -57,14 +57,9 @@ export async function sendFetch (url: string, options?: RequestInit) {
 }
 
 export function cacheDirectory () {
-  const dotGiget = resolve(homedir(), ".giget");
-  if (platform() === "linux" && !existsSync(dotGiget)) {
-    const CACHE_HOME = process.env.XDG_CACHE_HOME || resolve(homedir(), ".cache");
-    const gigetCache = resolve(CACHE_HOME, "giget");
-    return gigetCache;
-  } else {
-    return dotGiget;
-  }
+  return process.env.XDG_CACHE_HOME
+    ? resolve(process.env.XDG_CACHE_HOME, "giget")
+    : resolve(homedir(), ".cache/giget");
 }
 
 // -- Experimental --

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -2,6 +2,7 @@ import { createWriteStream, existsSync } from "node:fs";
 import { pipeline } from "node:stream";
 import { spawnSync } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
+import { homedir, platform } from "node:os";
 import { promisify } from "node:util";
 import { relative, resolve } from "pathe";
 import { fetch } from "node-fetch-native";
@@ -53,6 +54,17 @@ export async function sendFetch (url: string, options?: RequestInit) {
   const proxy = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
   const requestOptions = proxy ? { agent: createHttpsProxyAgent(proxy), ...options } : options;
   return await fetch(url, requestOptions);
+}
+
+export function cacheDirectory () {
+  const dotGiget = resolve(homedir(), ".giget");
+  if (platform() === "linux" && !existsSync(dotGiget)) {
+    const CACHE_HOME = process.env.XDG_CACHE_HOME || resolve(homedir(), ".cache");
+    const gigetCache = resolve(CACHE_HOME, "giget");
+    return gigetCache;
+  } else {
+    return dotGiget;
+  }
 }
 
 // -- Experimental --

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -1,10 +1,9 @@
 import { mkdir, rm } from "node:fs/promises";
-import { homedir } from "node:os";
 import { existsSync, readdirSync } from "node:fs";
 import { extract } from "tar";
 import { resolve, dirname } from "pathe";
 import { defu } from "defu";
-import { download, debug } from "./_utils";
+import { cacheDirectory, download, debug } from "./_utils";
 import { providers } from "./providers";
 import { registryProvider } from "./registry";
 import type { TemplateInfo, TemplateProvider } from "./types";
@@ -63,7 +62,7 @@ export async function downloadTemplate (input: string, options: DownloadTemplate
   }
   await mkdir(extractPath, { recursive: true });
 
-  const temporaryDirectory = resolve(homedir(), ".giget", options.provider, template.name);
+  const temporaryDirectory = resolve(cacheDirectory(), options.provider, template.name);
   const tarPath = resolve(temporaryDirectory, (template.version || template.name) + ".tar.gz");
 
   if (options.preferOffline && existsSync(tarPath)) {


### PR DESCRIPTION
# Background

Currently, giget downloads data to `~/.giget`, which isn't a standard path. However, on Linux, the XDG Base Directory Specification[^1].
It states the following:
>  There is a single base directory relative to which user-specific non-essential (cached) data should be written. This directory is defined by the environment variable `$XDG_CACHE_HOME`.

And later:
> `$XDG_CACHE_HOME` defines the base directory relative to which user-specific non-essential data files should be stored. If `$XDG_CACHE_HOME` is either not set or empty, a default equal to `$HOME/.cache` should be used. 


# What does this PR do

I added a function called `cacheDirectory` to `_utils.ts`, which checks if the user is on Linux and if the `~/.giget` directory doesn't already exist.
In the event that both of these are true, giget will try and use `$XDG_CACHE_HOME/giget`, and if `$XDG_CACHE_HOME` is not set, it'll use `$HOME/.cache`.
Otherwise, it will just use `~/.giget` to be consistent with the existing behavior.
https://github.com/YaBoiBurner/giget/blob/feat/xdg/src/_utils.ts#L59-L68

That function is now used in `giget.ts` when setting what the download directory should be.

[^1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html