### PR TITLE
feat: add tar provider, more tests, adjust vitest config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 node_modules
 *.log*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ npx giget@latest bitbucket:unjs/template
 
 # Clone from sourcehut
 npx giget@latest sourcehut:pi0/unjs-template
+
+# Clone from custom registry using tar
+npx giget@latest tar:https://github.com/unjs/unstorage/archive/refs/tags/v0.6.0.tar.gz#name=unstorage
 ```
 
 ## Template Registry
@@ -129,10 +132,10 @@ const { source, dir } = await downloadTemplate("github:unjs/template");
 
 **Options:**
 
-- `source`: (string) Input source in format of `[provider]:repo[/subpath][#ref]`.
+- `source`: (string) Input source in format of `[provider]:repo[/subpath][#ref]`. For `tar` provider only format should be `tar:[url]#name=[name]` or simply `tar:[url]#[name]`.
 - `options`: (object) Options are usually inferred from the input string. You can customize them.
   - `dir`: (string) Destination directory to clone to. If not provided, `user-name` will be used relative to the current directory.
-  - `provider`: (string) Either `github`, `gitlab`, `bitbucket` or `sourcehut`. The default is `github`.
+  - `provider`: (string) Either `github`, `gitlab`, `bitbucket`, `sourcehut` or `tar`. The default is `github`.
   - `repo`: (string) Name of repository in format of `{username}/{reponame}`.
   - `ref`: (string) Git ref (branch or commit or tag). The default value is `main`.
   - `subdir`: (string) Directory of the repo to clone from. The default value is none.

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -8,7 +8,7 @@ import type { Agent } from "node:http";
 import { relative, resolve } from "pathe";
 import { fetch } from "node-fetch-native";
 import createHttpsProxyAgent from "https-proxy-agent";
-import type { GitInfo } from "./types";
+import type { GitInfo, TarInfo } from "./types";
 
 export async function download(
   url: string,
@@ -53,6 +53,23 @@ export function parseGitURI(input: string): GitInfo {
     repo: m.repo,
     subdir: m.subdir || "/",
     ref: m.ref ? m.ref.slice(1) : "main",
+  };
+}
+
+const tarInputRegex =
+  /^(?<url>https?:\/\/[\w./-]+)(#(name=)?)?(?<name>[\w.-]+)?((#(version|v)=)(?<version>[\w.-]+))?/;
+
+export function parseTarURI(input: string): TarInfo {
+  const m = input.match(tarInputRegex)?.groups;
+
+  if (!m?.url) {
+    throw new Error(`Failed to parse tar url: ${input}`);
+  }
+
+  return <TarInfo>{
+    url: m.url,
+    name: m.name || "",
+    version: m.version || "",
   };
 }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,5 +1,5 @@
 import type { TemplateProvider } from "./types";
-import { parseGitURI } from "./_utils";
+import { parseGitURI, parseTarURI } from "./_utils";
 
 export const github: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
@@ -59,10 +59,25 @@ export const sourcehut: TemplateProvider = (input, options) => {
   };
 };
 
+export const tar: TemplateProvider = (input, options) => {
+  const parsed = parseTarURI(input);
+  return {
+    name: parsed.name,
+    version: parsed.version,
+    subdir: "/",
+    headers: {
+      authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+    },
+    url: parsed.url,
+    tar: parsed.url,
+  };
+};
+
 export const providers: Record<string, TemplateProvider> = {
   github,
   gh: github,
   gitlab,
   bitbucket,
   sourcehut,
+  tar,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ export interface GitInfo {
   ref: string;
 }
 
+export interface TarInfo {
+  url: string;
+  name: string;
+  version: string;
+}
+
 export interface TemplateInfo {
   name: string;
   tar: string;

--- a/test/getgit.test.ts
+++ b/test/getgit.test.ts
@@ -26,4 +26,43 @@ describe("downloadTemplate", () => {
       downloadTemplate("gh:unjs/template", { dir: destinationDirectory })
     ).rejects.toThrow("already exists");
   });
+
+  it("clone bitbucket unjs/template", async () => {
+    const destinationDirectory = resolve(__dirname, ".tmp/cloned-bitbucket");
+    const { dir } = await downloadTemplate("bitbucket:unjs/template", {
+      dir: destinationDirectory,
+      preferOffline: true,
+    });
+    expect(await existsSync(resolve(dir, "package.json")));
+  });
+
+  it("clone gitlab unjs/template", async () => {
+    const destinationDirectory = resolve(__dirname, ".tmp/cloned-gitlab");
+    const { dir } = await downloadTemplate("gitlab:unjs/template", {
+      dir: destinationDirectory,
+      preferOffline: true,
+    });
+    expect(await existsSync(resolve(dir, "package.json")));
+  });
+
+  it("clone gitlab unjs/template", async () => {
+    const destinationDirectory = resolve(__dirname, ".tmp/cloned-sourcehut");
+    const { dir } = await downloadTemplate("sourcehut:pi0/unjs-template", {
+      dir: destinationDirectory,
+      preferOffline: true,
+    });
+    expect(await existsSync(resolve(dir, "package.json")));
+  });
+
+  it("clone tar unjs/template", async () => {
+    const destinationDirectory = resolve(__dirname, ".tmp/cloned-tar");
+    const { dir } = await downloadTemplate(
+      "tar:https://github.com/unjs/unstorage/archive/refs/tags/v0.6.0.tar.gz",
+      {
+        dir: destinationDirectory,
+        preferOffline: true,
+      }
+    );
+    expect(await existsSync(resolve(dir, "package.json")));
+  });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from "vitest";
-import { parseGitURI } from "../src/_utils";
+import { parseGitURI, parseTarURI } from "../src/_utils";
 
 describe("parseGitURI", () => {
   const defaults = { repo: "org/repo", subdir: "/", ref: "main" };
@@ -17,4 +17,65 @@ describe("parseGitURI", () => {
       });
     });
   }
+});
+
+describe("parseTarURI", () => {
+  const tests = [
+    {
+      input: "https://my-registry.com/storage/my-repo/v1.0.0/tar.gz#name=foo",
+      output: {
+        url: "https://my-registry.com/storage/my-repo/v1.0.0/tar.gz",
+        name: "foo",
+        version: "",
+      },
+    },
+    {
+      input: "http://my-registry.com/storage/my-repo/v2.0.0/tar.gz#foo",
+      output: {
+        url: "http://my-registry.com/storage/my-repo/v2.0.0/tar.gz",
+        name: "foo",
+        version: "",
+      },
+    },
+    {
+      input:
+        "https://my-registry.com/storage/my-repo/v3.0.0/tar.gz#bar#version=3",
+      output: {
+        url: "https://my-registry.com/storage/my-repo/v3.0.0/tar.gz",
+        name: "bar",
+        version: "3",
+      },
+    },
+    {
+      input:
+        "https://my-registry.com/storage/my-repo/v4.0.0/tar.gz#bar#badparam",
+      output: {
+        url: "https://my-registry.com/storage/my-repo/v4.0.0/tar.gz",
+        name: "bar",
+        version: "",
+      },
+    },
+    {
+      input:
+        "https://my-registry.com/storage/my-repo/v5.0.0/tar.gz?somequery=someparam",
+      output: {
+        url: "https://my-registry.com/storage/my-repo/v5.0.0/tar.gz",
+        name: "",
+        version: "",
+      },
+    },
+  ];
+
+  for (const test of tests) {
+    it(test.input, () => {
+      expect(parseTarURI(test.input)).toMatchObject(test.output);
+    });
+  }
+
+  const invalidUrl = "//no-protocol.com";
+  it(invalidUrl, () => {
+    expect(() => parseTarURI(invalidUrl)).toThrowError(
+      `Failed to parse tar url: ${invalidUrl}`
+    );
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    exclude: [
+      "**/node_modules/**",
+      "./test/.tmp/**"
+    ],
     coverage: {
-      reporter: ["text", "clover", "json"]
+      reporter: ["text", "clover", "json"],
     }
   }
 });


### PR DESCRIPTION
Should resolve #10 

@pi0 I had to change proposed pattern to replace `&=version` with `#version`. Ampersand (`&`) could be evaluated by most terminals as next command if you do not wrap in quotes. So I propose to use `[url]#name=[name]#version=[version]`.
Though I am not sure if `version` is really needed and useful. See my comment in the diff.
