### PR TITLE
fix(github): use `api.github.com` for private repository support

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -3,16 +3,22 @@ import { parseGitURI } from "./_utils";
 
 export const github: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
-  const github = process.env.GIGET_GITHUB_URL || "https://api.github.com";
+
+  // https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-tar
+  // TODO: Verify solution for github enterprise
+  const githubAPIURL = process.env.GIGET_GITHUB_URL || "https://api.github.com";
+
   return {
     name: parsed.repo.replace("/", "-"),
     version: parsed.ref,
     subdir: parsed.subdir,
     headers: {
-      authorization: options.auth ? `token ${options.auth}` : undefined,
+      Authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28'
     },
-    url: `${github}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
-    tar: `${github}/repos/${parsed.repo}/tarball/${parsed.ref}`,
+    url: `${githubAPIURL.replace('api.github.com', 'github.com')}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
+    tar: `${githubAPIURL}/repos/${parsed.repo}/tarball/${parsed.ref}`,
   };
 };
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -3,16 +3,16 @@ import { parseGitURI } from "./_utils";
 
 export const github: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
-  const github = process.env.GIGET_GITHUB_URL || "https://github.com";
+  const github = process.env.GIGET_GITHUB_URL || "https://api.github.com";
   return {
     name: parsed.repo.replace("/", "-"),
     version: parsed.ref,
     subdir: parsed.subdir,
     headers: {
-      authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      authorization: options.auth ? `token ${options.auth}` : undefined,
     },
     url: `${github}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
-    tar: `${github}/${parsed.repo}/archive/${parsed.ref}.tar.gz`,
+    tar: `${github}/repos/${parsed.repo}/tarball/${parsed.ref}`,
   };
 };
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -14,10 +14,12 @@ export const github: TemplateProvider = (input, options) => {
     subdir: parsed.subdir,
     headers: {
       Authorization: options.auth ? `Bearer ${options.auth}` : undefined,
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28'
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
     },
-    url: `${githubAPIURL.replace('api.github.com', 'github.com')}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
+    url: `${githubAPIURL.replace("api.github.com", "github.com")}/${
+      parsed.repo
+    }/tree/${parsed.ref}${parsed.subdir}`,
     tar: `${githubAPIURL}/repos/${parsed.repo}/tarball/${parsed.ref}`,
   };
 };


### PR DESCRIPTION
Hey,

So far this project uses the url 

```
https://github.com/<owner>/<repo>/archive/<ref>.tar.gz
```

This url does not work for private repositories since Github returns 404 response. 

I have changed this url to, 


```
https://api.github.com/repos/<owner>/<repo>/tarball/<ref>
```

This url can be used for public repositories(without a token) and private repositories with a token and it receives a tarball in response same as before. 