### PR TITLE
fix(gitlab): workaround hotlinking  protection (406 Not Acceptable)

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -88,9 +88,13 @@ export async function sendFetch(
     }
   }
 
+  // https://github.com/nodejs/undici/issues/1305
+  if (options.headers?.["sec-fetch-mode"]) {
+    options.mode = options.headers["sec-fetch-mode"] as any;
+  }
+
   const res = await fetch(url, {
     ...options,
-    mode: "same-origin",
     headers: normalizeHeaders(options.headers),
   });
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -90,6 +90,7 @@ export async function sendFetch(
 
   const res = await fetch(url, {
     ...options,
+    mode: "same-origin",
     headers: normalizeHeaders(options.headers),
   });
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -92,6 +92,7 @@ export const gitlab: TemplateProvider = (input, options) => {
     subdir: parsed.subdir,
     headers: {
       authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      // https://gitlab.com/gitlab-org/gitlab/-/commit/50c11f278d18fe1f3fb12eb595067216bb58ade2
       "sec-fetch-mode": "same-origin",
     },
     url: `${gitlab}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -92,6 +92,7 @@ export const gitlab: TemplateProvider = (input, options) => {
     subdir: parsed.subdir,
     headers: {
       authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      "sec-fetch-mode": "same-origin",
     },
     url: `${gitlab}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
     tar: `${gitlab}/${parsed.repo}/-/archive/${parsed.ref}.tar.gz`,


### PR DESCRIPTION
**problem:** 
https://github.com/unjs/giget/issues/97

**reason:** 
This returns an Error 406, Im guessing due to the hotlinking rules
https://gitlab.com/gitlab-org/gitlab/-/commit/50c11f278d18fe1f3fb12eb595067216bb58ade2

**solved:**
need to add a mode `mode: 'same-origin'` in fetch  that solves the problem.