### PR TITLE
feat: support cloning from http(s) inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ npx giget@latest bitbucket:unjs/template
 
 # Clone from sourcehut
 npx giget@latest sourcehut:pi0/unjs-template
+
+# Clone from https URL (tarball)
+npx giget@latest https://api.github.com/repos/unjs/template/tarball/main
+
+# Clone from https URL (JSON)
+npx giget@latest https://raw.githubusercontent.com/unjs/giget/main/templates/unjs.json
 ```
 
 ## Template Registry

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "defu": "^6.1.3",
     "https-proxy-agent": "^7.0.2",
     "node-fetch-native": "^1.4.1",
+    "ohash": "^1.1.3",
     "pathe": "^1.1.1",
     "tar": "^6.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   node-fetch-native:
     specifier: ^1.4.1
     version: 1.4.1
+  ohash:
+    specifier: ^1.1.3
+    version: 1.1.3
   pathe:
     specifier: ^1.1.1
     version: 1.1.1
@@ -3357,7 +3360,6 @@ packages:
 
   /ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
-    dev: true
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -67,6 +67,7 @@ export function debug(...args: unknown[]) {
 interface InternalFetchOptions extends Omit<RequestInit, "headers"> {
   headers?: Record<string, string | undefined>;
   agent?: Agent;
+  validateStatus?: boolean;
 }
 
 export async function sendFetch(
@@ -87,10 +88,16 @@ export async function sendFetch(
     }
   }
 
-  return await fetch(url, {
+  const res = await fetch(url, {
     ...options,
     headers: normalizeHeaders(options.headers),
   });
+
+  if (options.validateStatus && res.status >= 400) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+
+  return res;
 }
 
 export function cacheDirectory() {

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -44,13 +44,18 @@ export async function downloadTemplate(
     options.registry === false
       ? undefined
       : registryProvider(options.registry, { auth: options.auth });
+
   let providerName: string =
     options.provider || (registry ? "registry" : "github");
+
   let source: string = input;
   const sourceProvierMatch = input.match(sourceProtoRe);
   if (sourceProvierMatch) {
     providerName = sourceProvierMatch[1];
     source = input.slice(sourceProvierMatch[0].length);
+    if (providerName === "http" || providerName === "https") {
+      source = input;
+    }
   }
 
   const provider =

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,5 +1,67 @@
-import type { TemplateProvider } from "./types";
-import { parseGitURI } from "./_utils";
+import { basename } from "pathe";
+import type { TemplateInfo, TemplateProvider } from "./types";
+import { debug, parseGitURI, sendFetch } from "./_utils";
+
+export const http: TemplateProvider = async (input, options) => {
+  if (input.endsWith(".json")) {
+    return (await _httpJSON(input, options)) as TemplateInfo;
+  }
+
+  const url = new URL(input);
+  let name: string = basename(url.pathname);
+
+  try {
+    const head = await sendFetch(url.href, {
+      method: "HEAD",
+      validateStatus: true,
+      headers: {
+        authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      },
+    });
+    const _contentType = head.headers.get("content-type") || "";
+    if (
+      _contentType.includes("application/json") ||
+      _contentType.includes("text/plain") /* GitHub raw */
+    ) {
+      return (await _httpJSON(input, options)) as TemplateInfo;
+    }
+    const filename = head.headers
+      .get("content-disposition")
+      ?.match(/filename="?(.+)"?/)?.[1];
+    if (filename) {
+      name = filename.split(".")[0];
+    }
+  } catch (error) {
+    debug(`Failed to fetch HEAD for ${url.href}:`, error);
+  }
+
+  return {
+    name: `${name}-${url.href.slice(0, 8)}`,
+    version: "",
+    subdir: "",
+    tar: url.href,
+    defaultDir: name,
+    headers: {
+      Authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+    },
+  };
+};
+
+const _httpJSON: TemplateProvider = async (input, options) => {
+  const result = await sendFetch(input, {
+    validateStatus: true,
+    headers: {
+      authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+    },
+  });
+  const info = (await result.json()) as TemplateInfo;
+  if (!info.tar || !info.name) {
+    throw new Error(
+      `Invalid template info from ${input}. name or tar fields are missing!`,
+    );
+  }
+  return info;
+};
 
 export const github: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
@@ -68,6 +130,8 @@ export const sourcehut: TemplateProvider = (input, options) => {
 };
 
 export const providers: Record<string, TemplateProvider> = {
+  http,
+  https: http,
   github,
   gh: github,
   gitlab,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #10

previous works #86, #91 ❤️ 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for input to using `http://` or `https://` protocols. 

If the path ends with `.json` or a response content type with `HEAD` method is `application/json` or `text/plain` (for the sake of GH raw content!), we download JSON as Template info.

Otherwise we try to guess name from URL's last segment (basename) or `content-disposition` `filename` header if provided in `HEAD` response as default name. 

The fragment support as proposed in initial issue is not implemented as I think with JSON support now we have enough power to control responses without making inputs more complex but PR welcome if there are valid cases for it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
