### PR TITLE
fix(cli): display the current directory when cloning into current dir

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,10 +74,7 @@ const mainCommand = defineCommand({
     });
 
     const _from = r.name || r.url;
-    const _to =
-      process.cwd() === r.dir
-        ? "the current directory"
-        : relative(process.cwd(), r.dir);
+    const _to = process.cwd() === r.dir ? "./" : relative(process.cwd(), r.dir);
     consola.log(`✨ Successfully cloned \`${_from}\` to \`${_to}\`\n`);
 
     if (args.shell) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,7 @@ const mainCommand = defineCommand({
     });
 
     const _from = r.name || r.url;
-    const _to = process.cwd() === r.dir ? "./" : relative(process.cwd(), r.dir);
+    const _to = relative(process.cwd(), r.dir) || "./";
     consola.log(`✨ Successfully cloned \`${_from}\` to \`${_to}\`\n`);
 
     if (args.shell) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,10 @@ const mainCommand = defineCommand({
     });
 
     const _from = r.name || r.url;
-    const _to = relative(process.cwd(), r.dir);
+    const _to =
+      process.cwd() === r.dir
+        ? "the current directory"
+        : relative(process.cwd(), r.dir);
     consola.log(`✨ Successfully cloned \`${_from}\` to \`${_to}\`\n`);
 
     if (args.shell) {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The success message after cloning a template into the current directory is a little confusing:

![Screenshot 2023-12-23 at 15 49 58 (kitty)](https://github.com/unjs/giget/assets/47499684/526c7412-d6b1-4042-8c4d-0bd558986941)

Where was it cloned? Did it work?

Not sure if this is the ideal solution for y'all but with this PR it looks like this instead:

![Screenshot 2023-12-23 at 15 52 52 (kitty)](https://github.com/unjs/giget/assets/47499684/857c1837-c736-4694-89b4-9f26ea659a35)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
