### PR TITLE
fix: correct gitlab repository path

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -95,8 +95,8 @@ export const gitlab: TemplateProvider = (input, options) => {
       // https://gitlab.com/gitlab-org/gitlab/-/commit/50c11f278d18fe1f3fb12eb595067216bb58ade2
       "sec-fetch-mode": "same-origin",
     },
-    url: `${gitlab}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
-    tar: `${gitlab}/${parsed.repo}/-/archive/${parsed.ref}.tar.gz`,
+    url: `${gitlab}/${parsed.repo}${parsed.subdir}/tree/${parsed.ref}`,
+    tar: `${gitlab}/${parsed.repo}${parsed.subdir}/-/archive/${parsed.ref}.tar.gz`,
   };
 };
 


### PR DESCRIPTION
### 🔗 Linked issue

#107 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Gitlab supports nested subgroups, like `https://gitlab.com/{groupName}/{subgroupName}/{repoName}`. Attempting to pull any subgroup would result in a 403 error. This pull request resolves the issue.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
