### PR TITLE
fix(parseGitURI): support `@` symbol in ref segment

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -46,7 +46,7 @@ export async function download(
 }
 
 const inputRegex =
-  /^(?<repo>[\w.-]+\/[\w.-]+)(?<subdir>[^#]+)?(?<ref>#[\w./-]+)?/;
+  /^(?<repo>[\w.-]+\/[\w.-]+)(?<subdir>[^#]+)?(?<ref>#[\w./@-]+)?/;
 
 export function parseGitURI(input: string): GitInfo {
   const m = input.match(inputRegex)?.groups || {};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -8,6 +8,7 @@ describe("parseGitURI", () => {
     { input: "org/repo#ref", output: { ref: "ref" } },
     { input: "org/repo#ref-123", output: { ref: "ref-123" } },
     { input: "org/repo#ref/ABC-123", output: { ref: "ref/ABC-123" } },
+    { input: "org/repo#@org/tag@1.2.3", output: { ref: "@org/tag@1.2.3" } },
     { input: "org/repo/foo/bar", output: { subdir: "/foo/bar" } },
   ];
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#152 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->

Adds support for `@` characters in `parseGitURI`'s `inputRegex`.

<!-- Why is this change required? What problem does it solve? -->

Since the `@` character is not included in the `<ref>` character set `[\w./-]`, tags containing `@` won't be matched by this pattern, and will fallback to `main`.  See linked issue for more detail.

Resolves #152

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- ~[ ] I have updated the documentation accordingly.~ N/A, 
