### PR TITLE
fix!: use correct temp dir in windows for cache

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -2,7 +2,7 @@ import { createWriteStream, existsSync } from "node:fs";
 import { pipeline } from "node:stream";
 import { spawnSync } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, platform, tmpdir } from "node:os";
 import { promisify } from "node:util";
 import type { Agent } from "node:http";
 import { relative, resolve } from "pathe";
@@ -94,6 +94,10 @@ export async function sendFetch(
 }
 
 export function cacheDirectory() {
+  if (platform() === "win32") {
+    return resolve(tmpdir(), "giget");
+  }
+
   return process.env.XDG_CACHE_HOME
     ? resolve(process.env.XDG_CACHE_HOME, "giget")
     : resolve(homedir(), ".cache/giget");

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -98,7 +98,9 @@ export function cacheDirectory() {
 
   if (process.platform === "win32") {
     const windowsCacheDir = resolve(tmpdir(), "giget");
-    // on windows, move old cache directory to new location
+    // Migrate cache dir to new location
+    // https://github.com/unjs/giget/pull/182/
+    // TODO: remove in next releases
     if (!existsSync(windowsCacheDir) && existsSync(cacheDir)) {
       try {
         renameSync(cacheDir, windowsCacheDir);


### PR DESCRIPTION
Resolves #178 

On Windows, the template cache is moved to the user's temp directory (%temp%/giget). This follows the correct OS conventions and allows Windows storage utils (Disk Clean-up, Storage Sense) to delete the cache to free storage if the user desires.

It will move the cache directory if oldDir && !newDir. This logic requires running `resolve()` to get both the Windows and other OS cache paths at the same time and `existsSync()` twice on Windows. We remove the migration code after some time in the future, and simplify to [`437adc3` (#182)](https://github.com/unjs/giget/pull/182/commits/437adc3f6e56c6445043c617f4811745ddb23b3e)

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
