### PR TITLE
feat: support bitbucket self-hosted

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -105,6 +105,21 @@ export const bitbucket: TemplateProvider = (input, options) => {
   const bitbucketURL =
     process.env.GIGET_BITBUCKET_URL || "https://bitbucket.org";
 
+  let paths: Pick<TemplateInfo, "url" | "tar"> = {
+    url: `${bitbucketURL}/${parsed.repo}/src/${parsed.ref}${parsed.subdir}`,
+    tar: `${bitbucketURL}/${parsed.repo}/get/${parsed.ref}.tar.gz`,
+  };
+
+  // Self-hosted Bitbucket paths
+  if (bitbucketURL !== "https://bitbucket.org") {
+    const [project, repo] = parsed.repo.split("/");
+
+    paths = {
+      url: `${bitbucketURL}/projects/${project}/repos/${repo}/browse${parsed.subdir}?at=${parsed.ref}`,
+      tar: `${bitbucketURL}/rest/api/latest/projects/${project}/repos/${repo}/archive?at=${parsed.ref}&format=tar.gz`,
+    };
+  }
+
   return {
     name: parsed.repo.replace("/", "-"),
     version: parsed.ref,
@@ -112,8 +127,7 @@ export const bitbucket: TemplateProvider = (input, options) => {
     headers: {
       authorization: options.auth ? `Bearer ${options.auth}` : undefined,
     },
-    url: `${bitbucketURL}/${parsed.repo}/src/${parsed.ref}${parsed.subdir}`,
-    tar: `${bitbucketURL}/${parsed.repo}/get/${parsed.ref}.tar.gz`,
+    ...paths,
   };
 };
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -102,6 +102,9 @@ export const gitlab: TemplateProvider = (input, options) => {
 
 export const bitbucket: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
+  const bitbucketURL =
+    process.env.GIGET_BITBUCKET_URL || "https://bitbucket.org";
+
   return {
     name: parsed.repo.replace("/", "-"),
     version: parsed.ref,
@@ -109,8 +112,8 @@ export const bitbucket: TemplateProvider = (input, options) => {
     headers: {
       authorization: options.auth ? `Bearer ${options.auth}` : undefined,
     },
-    url: `https://bitbucket.com/${parsed.repo}/src/${parsed.ref}${parsed.subdir}`,
-    tar: `https://bitbucket.org/${parsed.repo}/get/${parsed.ref}.tar.gz`,
+    url: `${bitbucketURL}/${parsed.repo}/src/${parsed.ref}${parsed.subdir}`,
+    tar: `${bitbucketURL}/${parsed.repo}/get/${parsed.ref}.tar.gz`,
   };
 };
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/giget/issues/188

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

ENV: added `GIGET_BITBUCKET_URL`

### ❓ How to test

I found self-hosted in the public domain: https://bitbucket.hl7.org 

1. Set env `GIGET_BITBUCKET_URL=https://bitbucket.hl7.org`
2. Run command `pnpm run giget bitbucket:UTG/utg#master`

Here's my successful log:
```
~/giget main ❯ pnpm run giget bitbucket:UTG/utg#master

> giget@1.2.3 giget /Users/Hywax/giget
> jiti ./src/cli.ts "bitbucket:UTG/utg#master"

✨ Successfully cloned UTG-utg to UTG-utg 
```