### PR TITLE
fix: patch tar for bun on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,10 @@
     "unbuild": "^3.3.1",
     "vitest": "^3.0.7"
   },
-  "packageManager": "pnpm@10.5.0"
+  "packageManager": "pnpm@10.5.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "tar": "patches/tar.patch"
+    }
+  }
 }

--- a/patches/tar.patch
+++ b/patches/tar.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/get-write-flag.js b/lib/get-write-flag.js
+index e86959996623c897ee8440acc34441e46bd44678..35f547982001b132751eff64d39cc25caa1ae6b9 100644
+--- a/lib/get-write-flag.js
++++ b/lib/get-write-flag.js
+@@ -7,7 +7,7 @@
+ // it can be a big boost on Windows platforms.
+ // Only supported in Node v12.9.0 and above.
+ const platform = process.env.__FAKE_PLATFORM__ || process.platform
+-const isWindows = platform === 'win32'
++const isWindows = typeof Bun !== "undefined" ? false : platform === 'win32'
+ const fs = global.__FAKE_TESTING_FS__ || require('fs')
+ 
+ /* istanbul ignore next */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  tar:
+    hash: bb65a63b0a70c4bc0f0bb4105dbab29307c2cfa90445b6b63ac1c3a27009436e
+    path: patches/tar.patch
+
 importers:
 
   .:
@@ -56,7 +61,7 @@ importers:
         version: 3.5.2
       tar:
         specifier: ^6.2.1
-        version: 6.2.1
+        version: 6.2.1(patch_hash=bb65a63b0a70c4bc0f0bb4105dbab29307c2cfa90445b6b63ac1c3a27009436e)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -3514,7 +3519,7 @@ snapshots:
       node-fetch-native: 1.6.6
       nypm: 0.5.4
       pathe: 2.0.3
-      tar: 6.2.1
+      tar: 6.2.1(patch_hash=bb65a63b0a70c4bc0f0bb4105dbab29307c2cfa90445b6b63ac1c3a27009436e)
 
   glob-parent@5.1.2:
     dependencies:
@@ -4292,7 +4297,7 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  tar@6.2.1:
+  tar@6.2.1(patch_hash=bb65a63b0a70c4bc0f0bb4105dbab29307c2cfa90445b6b63ac1c3a27009436e):
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0


### PR DESCRIPTION
This PR patches tar v6 issue with Bun on windows (https://github.com/unjs/giget/pull/180, https://github.com/oven-sh/bun/issues/12696#issuecomment-2241324985) -- thanks to @Vexcited for investigation ❤️ 

(with #214 tar is bundled with giget)