### PR TITLE
Prevents duplicate error messages in CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,15 +69,28 @@ const mainCommand = defineCommand({
       process.env.DEBUG = process.env.DEBUG || "true";
     }
 
-    const r = await downloadTemplate(args.template, {
-      dir: args.dir,
-      force: args.force,
-      forceClean: args.forceClean,
-      offline: args.offline,
-      preferOffline: args.preferOffline,
-      auth: args.auth,
-      install: args.install,
-    });
+    let r: Awaited<ReturnType<typeof downloadTemplate>>
+    try {
+      r = await downloadTemplate(args.template, {
+        dir: args.dir,
+        force: args.force,
+        forceClean: args.forceClean,
+        offline: args.offline,
+        preferOffline: args.preferOffline,
+        auth: args.auth,
+        install: args.install,
+      })
+    } catch (error) {
+      if (args.verbose) {
+        consola.error(error)
+      } else {
+        const message = error instanceof Error ? error.message : `Failed to download ${args.template}: unknown error`
+        consola.error(message)
+      }
+
+      process.exitCode = 1
+      return
+    }
 
     const _from = r.name || r.url;
     const _to = relative(process.cwd(), r.dir) || "./";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,7 @@ const mainCommand = defineCommand({
       process.env.DEBUG = process.env.DEBUG || "true";
     }
 
-    let r: Awaited<ReturnType<typeof downloadTemplate>>
+    let r: Awaited<ReturnType<typeof downloadTemplate>>;
     try {
       r = await downloadTemplate(args.template, {
         dir: args.dir,
@@ -79,17 +79,20 @@ const mainCommand = defineCommand({
         preferOffline: args.preferOffline,
         auth: args.auth,
         install: args.install,
-      })
+      });
     } catch (error) {
       if (args.verbose) {
-        consola.error(error)
+        consola.error(error);
       } else {
-        const message = error instanceof Error ? error.message : `Failed to download ${args.template}: unknown error`
-        consola.error(message)
+        const message =
+          error instanceof Error
+            ? error.message
+            : `Failed to download ${args.template}: unknown error`;
+        consola.error(message);
       }
 
-      process.exitCode = 1
-      return
+      process.exitCode = 1;
+      return;
     }
 
     const _from = r.name || r.url;


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR slightly improves the cli error message by handling the error thrown by `downloadTemplate`:

- If `--verbose` is specified: print the full error stack; otherwise just print the error message
- Exit with code = 1

This prevents duplicate error message from being written into output, while also allow users to check the full error stack by using `--verbose` flag.

| Before | After |
|--------|-------|
| ![Screenshot 2025-04-19 165335](https://github.com/user-attachments/assets/423ad49b-347d-4c8a-ac1e-9fd16631675c) | ![Screenshot 2025-04-19 165245](https://github.com/user-attachments/assets/25ba2970-4acc-413a-ac44-c9b135f5b000) |