### PR TITLE
feat: support downloading raw files and conflict strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ npx giget@latest <template> [<dir>] [...options]
 - `--cwd`: Set the current working directory to resolve dirs relative to it.
 - `--auth`: Custom Authorization token to use for downloading template. (Can be overridden with `GIGET_AUTH` environment variable).
 - `--install`: Install dependencies after cloning using [unjs/nypm](https://github.com/unjs/nypm).
+- `--files <paths...>`: Download multiple files via raw URL. Specify a space-separated list of paths.
+- `--strategy <skip|overwrite>`: Strategy for existing file when using `--files`. Defaults to `skip`.
 
 ### Examples
 
@@ -83,6 +85,12 @@ npx giget@latest https://api.github.com/repos/unjs/template/tarball/main
 
 # Clone from https URL (JSON)
 npx giget@latest https://raw.githubusercontent.com/unjs/giget/main/templates/unjs.json
+
+# Download one file from github.com/unjs/giget:
+giget gh:unjs/giget --files README.md
+
+# Download multiple files or folders from the github.com/unjs/giget
+giget gh:unjs/giget --files LICENSE --files .github
 ```
 
 ## Template Registry

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,11 +63,29 @@ const mainCommand = defineCommand({
       type: "boolean",
       description: "Show verbose debugging info",
     },
+    strategy: {
+      type: "string",
+      description: "Strategy for existing file: skip or overwrite",
+      default: "skip",
+    },
+    files: {
+      type: "string",
+      description: "List of files (paths) to download via raw URL",
+      multiple: true,
+    },
   },
   run: async ({ args }) => {
     if (args.verbose) {
       process.env.DEBUG = process.env.DEBUG || "true";
     }
+
+    // Normalize files argument into string[] if provided
+    const filesList: string[] | undefined =
+      args.files === undefined
+        ? undefined
+        : (Array.isArray(args.files)
+          ? args.files
+          : [args.files]);
 
     const r = await downloadTemplate(args.template, {
       dir: args.dir,
@@ -77,6 +95,8 @@ const mainCommand = defineCommand({
       preferOffline: args.preferOffline,
       auth: args.auth,
       install: args.install,
+      files: filesList,
+      strategy: args.strategy as "skip" | "overwrite",
     });
 
     const _from = r.name || r.url;

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -105,7 +105,7 @@ export async function downloadTemplate(
     const destDir = resolve(cwd, options.dir || template.defaultDir);
     try {
       for (const filePath of files) {
-        const rawUrl = 'test' + template.raw(filePath.replace(/^\//, "")) + 'test';
+        const rawUrl = template.raw(filePath.replace(/^\//, ""));
         const outPath = resolve(destDir, filePath);
         await mkdir(dirname(outPath), { recursive: true });
         if (options.strategy !== "skip" || !existsSync(outPath)) {

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync } from "node:fs";
 // @ts-ignore
 import tarExtract from "tar/lib/extract.js";
 import type { ExtractOptions } from "tar";
-import { resolve, dirname } from "pathe";
+import { resolve, dirname, basename } from "pathe";
 import { defu } from "defu";
 import { installDependencies } from "nypm";
 import {
@@ -95,6 +95,7 @@ export async function downloadTemplate(
     "-",
   );
 
+  // Raw download attempt (fast path for specific files if options.files is provided)
   if (
     template.raw &&
     Array.isArray(options.files) &&
@@ -103,11 +104,14 @@ export async function downloadTemplate(
     const files = options.files;
     const cwd = resolve(options.cwd || ".");
     const destDir = resolve(cwd, options.dir || template.defaultDir);
+    let allFilesDownloadedRaw = true;
+
     try {
       for (const filePath of files) {
         const rawUrl = template.raw(filePath.replace(/^\//, ""));
         const outPath = resolve(destDir, filePath);
         await mkdir(dirname(outPath), { recursive: true });
+
         if (options.strategy !== "skip" || !existsSync(outPath)) {
           const res = await sendFetch(rawUrl, {
             validateStatus: true,
@@ -118,26 +122,37 @@ export async function downloadTemplate(
               ...template.headers,
             }),
           });
+
           if (res.status >= 400) {
-            throw new Error(`Failed to fetch ${rawUrl}: ${res.status}`);
+            allFilesDownloadedRaw = false;
+            debug(
+              `Raw download failed for ${rawUrl} (status: ${res.status}). Falling back to tarball.`,
+            );
+            break; // Exit loop, will proceed to tarball logic outside this block
           }
           const buffer = Buffer.from(await res.arrayBuffer());
           await writeFile(outPath, buffer);
         }
       }
 
-      // All files downloaded successfully
-      return {
-        ...template,
-        dir: destDir,
-        source: files.join(","),
-      };
-    } catch (error) {
-      debug("Raw files download failed, falling back to tarball flow:", error);
+      if (allFilesDownloadedRaw) {
+        return {
+          ...template,
+          dir: destDir,
+          source: files.join(", "),
+        };
+      }
+    } catch (error: any) {
+      allFilesDownloadedRaw = false;
+      debug(
+        "Raw files download process failed:",
+        error.message,
+        "Falling back to tarball flow.",
+      );
     }
   }
 
-  // Download template source
+  // --- Tarball Download and Unified Extraction Logic ---
   const temporaryDirectory = resolve(
     cacheDirectory(),
     providerName,
@@ -151,6 +166,7 @@ export async function downloadTemplate(
   if (options.preferOffline && existsSync(tarPath)) {
     options.offline = true;
   }
+
   if (!options.offline) {
     await mkdir(dirname(tarPath), { recursive: true });
     const s = Date.now();
@@ -167,7 +183,10 @@ export async function downloadTemplate(
       debug("Download error. Using cached version:", error);
       options.offline = true;
     });
-    debug(`Downloaded ${template.tar} to ${tarPath} in ${Date.now() - s}ms`);
+    if (!options.offline) {
+      // Log only if a download was attempted and succeeded
+      debug(`Downloaded ${template.tar} to ${tarPath} in ${Date.now() - s}ms`);
+    }
   }
 
   if (!existsSync(tarPath)) {
@@ -176,64 +195,100 @@ export async function downloadTemplate(
     );
   }
 
-  // Partial tarball extraction for file/folder paths when --files is used
-  if (options.files && options.files.length > 0) {
-    const cwdPart = resolve(options.cwd || ".");
-    const extractPart = resolve(cwdPart, options.dir || template.defaultDir);
-    // ensure destination exists
-    await mkdir(extractPart, { recursive: true });
-    // Remove any leading/trailing slashes for accurate matching
-    const filterPaths = options.files.map((p) => p.replace(/^\/+|\/+$/g, ""));
-    await tarExtract(<ExtractOptions>{
-      file: tarPath,
-      cwd: extractPart,
-      strip: 1,
-      filter: (entryPath: string) => {
-        const rel = entryPath.split("/").slice(1).join("/");
-        return filterPaths.some((fp) => rel === fp || rel.startsWith(fp + "/"));
-      },
-    });
-    return {
-      ...template,
-      dir: extractPart,
-      source: options.files.join(","),
-    };
-  }
-
-  // Extract template
   const cwd = resolve(options.cwd || ".");
   const extractPath = resolve(cwd, options.dir || template.defaultDir);
+
   if (options.forceClean) {
     await rm(extractPath, { recursive: true, force: true });
   }
-  // For top-level repo clones (no subdir), prevent overwriting existing non-empty dir
-  const extractSubdir = template.subdir?.replace(/^\//, "") || "";
+
+  const normalizedSubdirForCheck = template.subdir
+    ? template.subdir.replace(/^\/+|\/+$/g, "")
+    : "";
+  const isFullCloneOrRootDir =
+    !normalizedSubdirForCheck || normalizedSubdirForCheck === ".";
+  debug(
+    `Overwrite check: template.subdir="${template.subdir}", normalizedSubdirForCheck="${normalizedSubdirForCheck}", isFullCloneOrRootDir=${isFullCloneOrRootDir}, strategy="${options.strategy}", extractPath="${extractPath}"`,
+  );
+
   if (
     !options.force &&
+    !(options.files && options.files.length > 0) &&
+    isFullCloneOrRootDir &&
     existsSync(extractPath) &&
-    readdirSync(extractPath).length > 0 &&
-    extractSubdir === ""
+    readdirSync(extractPath).length > 0
   ) {
-    throw new Error(`Destination ${extractPath} already exists.`);
+    if (options.strategy === "overwrite") {
+      debug(
+        `Destination ${extractPath} exists and is not empty, but strategy is "overwrite". Proceeding with extraction.`,
+      );
+    } else if (options.strategy === "skip") {
+      debug(
+        `Skipping extraction for ${input}: destination ${extractPath} exists, is not empty, and strategy is "skip".`,
+      );
+      return {
+        ...template,
+        dir: extractPath,
+        source,
+      };
+    } else {
+      throw new Error(
+        `Destination ${extractPath} already exists and is not empty. Use --force, --strategy=overwrite to overwrite, or --strategy=skip to skip.`,
+      );
+    }
   }
   await mkdir(extractPath, { recursive: true });
 
   const s = Date.now();
-  const subdir = template.subdir?.replace(/^\//, "") || "";
   await tarExtract(<ExtractOptions>{
     file: tarPath,
     cwd: extractPath,
     onentry(entry) {
-      entry.path = entry.path.split("/").splice(1).join("/");
-      if (subdir) {
-        // eslint-disable-next-line unicorn/prefer-ternary
-        if (entry.path.startsWith(subdir + "/")) {
-          // Rewrite path
-          entry.path = entry.path.slice(subdir.length);
-        } else {
-          // Skip
+      const pathFromTar = entry.path;
+      const firstSlashIndex = pathFromTar.indexOf("/");
+
+      if (firstSlashIndex === -1) {
+        entry.path = ""; // Skip this entry
+        return;
+      }
+
+      const effectivePath = pathFromTar.slice(firstSlashIndex + 1);
+      const normalizedSubdir = template.subdir
+        ? template.subdir.replace(/^\/+|\/+$/g, "")
+        : "";
+
+      if (options.files && options.files.length > 0) {
+        const normalizedFileTargets = options.files.map((p) =>
+          p.replace(/^\/+|\/+$/g, ""),
+        );
+
+        const shouldExtract = normalizedFileTargets.some((normalizedTarget) => {
+          if (effectivePath === normalizedTarget) return true;
+          if (effectivePath.startsWith(normalizedTarget + "/")) return true;
+          return false;
+        });
+
+        if (!shouldExtract) {
           entry.path = "";
+          return;
         }
+        entry.path = effectivePath;
+      } else if (
+        normalizedSubdir &&
+        normalizedSubdir !== "" &&
+        normalizedSubdir !== "."
+      ) {
+        if (effectivePath.startsWith(normalizedSubdir + "/")) {
+          entry.path = effectivePath.slice(normalizedSubdir.length + 1);
+        } else if (effectivePath === normalizedSubdir) {
+          entry.path =
+            entry.type === "Directory" ? "" : basename(effectivePath);
+        } else {
+          entry.path = "";
+          return;
+        }
+      } else {
+        entry.path = effectivePath;
       }
     },
   });
@@ -249,7 +304,10 @@ export async function downloadTemplate(
 
   return {
     ...template,
-    source,
+    source:
+      options.files && options.files.length > 0
+        ? options.files.join(", ")
+        : source,
     dir: extractPath,
   };
 }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -22,11 +22,13 @@ export const http: TemplateProvider = async (input, options) => {
     if (_contentType.includes("application/json")) {
       return (await _httpJSON(input, options)) as TemplateInfo;
     }
-    const filename = head.headers
-      .get("content-disposition")
-      ?.match(/filename="?(.+)"?/)?.[1];
-    if (filename) {
-      name = filename.split(".")[0];
+    const contentDisposition = head.headers.get("content-disposition");
+    if (contentDisposition) {
+      const match = contentDisposition.match(/filename="?(.+)"?/);
+      const filename = match?.[1];
+      if (filename) {
+        name = filename.split(".")[0]!;
+      }
     }
   } catch (error) {
     debug(`Failed to fetch HEAD for ${url.href}:`, error);
@@ -41,6 +43,7 @@ export const http: TemplateProvider = async (input, options) => {
     headers: {
       Authorization: options.auth ? `Bearer ${options.auth}` : undefined,
     },
+    raw: (path: string) => new URL(path, url.href).href,
   };
 };
 
@@ -80,6 +83,8 @@ export const github: TemplateProvider = (input, options) => {
       parsed.repo
     }/tree/${parsed.ref}${parsed.subdir}`,
     tar: `${githubAPIURL}/repos/${parsed.repo}/tarball/${parsed.ref}`,
+    raw: (path: string) =>
+      `https://raw.githubusercontent.com/${parsed.repo}/${parsed.ref}/${path}`,
   };
 };
 
@@ -97,6 +102,8 @@ export const gitlab: TemplateProvider = (input, options) => {
     },
     url: `${gitlab}/${parsed.repo}/tree/${parsed.ref}${parsed.subdir}`,
     tar: `${gitlab}/${parsed.repo}/-/archive/${parsed.ref}.tar.gz`,
+    raw: (path: string) =>
+      `${gitlab}/${parsed.repo}/-/raw/${parsed.ref}/${path}`,
   };
 };
 
@@ -111,6 +118,8 @@ export const bitbucket: TemplateProvider = (input, options) => {
     },
     url: `https://bitbucket.com/${parsed.repo}/src/${parsed.ref}${parsed.subdir}`,
     tar: `https://bitbucket.org/${parsed.repo}/get/${parsed.ref}.tar.gz`,
+    raw: (path: string) =>
+      `https://bitbucket.org/${parsed.repo}/raw/${parsed.ref}/${path}`,
   };
 };
 
@@ -125,6 +134,8 @@ export const sourcehut: TemplateProvider = (input, options) => {
     },
     url: `https://git.sr.ht/~${parsed.repo}/tree/${parsed.ref}/item${parsed.subdir}`,
     tar: `https://git.sr.ht/~${parsed.repo}/archive/${parsed.ref}.tar.gz`,
+    raw: (path: string) =>
+      `https://git.sr.ht/~${parsed.repo}/raw/${parsed.ref}/${path}`,
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface TemplateInfo {
   url?: string;
   defaultDir?: string;
   headers?: Record<string, string | undefined>;
+  raw?: (path: string) => string;
 
   // Added by giget
   source?: never;


### PR DESCRIPTION
Closes #222 

This PR adds support for downloading individual files via raw links and resolving conflicts via strategies (currently skip and overwrite, maybe merge in the future).

Todo:

1. Some code has been written by ai and I still need to review parts of it in detail.
2. Test if raw download links work for all providers. I have only tested it for GitHub so far.
3. Write test cases.