### PR TITLE
add authType provider option to handle Bitbucket Basic auth

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,10 @@ const mainCommand = defineCommand({
       description:
         "Custom Authorization token to use for downloading template. (Can be overriden with `GIGET_AUTH` environment variable)",
     },
+    authType: {
+      type: "string",
+      description: "Authorization type (can be `Basic` or `Bearer` by default)"
+    },
     cwd: {
       type: "string",
       description:
@@ -76,6 +80,7 @@ const mainCommand = defineCommand({
       offline: args.offline,
       preferOffline: args.preferOffline,
       auth: args.auth,
+      authType: args.authType,
       install: args.install,
     });
 

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -22,6 +22,7 @@ export interface DownloadTemplateOptions {
   registry?: false | string;
   cwd?: string;
   auth?: string;
+  authType?: string;
   install?: boolean;
   silent?: boolean;
 }
@@ -69,7 +70,7 @@ export async function downloadTemplate(
     throw new Error(`Unsupported provider: ${providerName}`);
   }
   const template = await Promise.resolve()
-    .then(() => provider(source, { auth: options.auth }))
+    .then(() => provider(source, { auth: options.auth, authType: options.authType }))
     .catch((error) => {
       throw new Error(
         `Failed to download template from ${providerName}: ${error.message}`,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -102,12 +102,14 @@ export const gitlab: TemplateProvider = (input, options) => {
 
 export const bitbucket: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
+  const bearerAuth = options.auth ? `Bearer ${options.auth}` : undefined
+	const basicAuth = options.auth ? `Basic ${Buffer.from(options.auth, 'utf8').toString('base64')}` : undefined
   return {
     name: parsed.repo.replace("/", "-"),
     version: parsed.ref,
     subdir: parsed.subdir,
     headers: {
-      authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      authorization: options.authType === 'Basic' ? basicAuth : bearerAuth,
     },
     url: `https://bitbucket.com/${parsed.repo}/src/${parsed.ref}${parsed.subdir}`,
     tar: `https://bitbucket.org/${parsed.repo}/get/${parsed.ref}.tar.gz`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,5 +23,5 @@ export interface TemplateInfo {
 
 export type TemplateProvider = (
   input: string,
-  options: { auth?: string },
+  options: { auth?: string, authType?: string },
 ) => TemplateInfo | Promise<TemplateInfo> | null;


### PR DESCRIPTION
Add a "authType" option to provider for reason to use "authType": "Basic" for Bitbucket "Basic" auth instead of "Bearer" auth (which is not supported by Bitbucket)

Resolve this issue -> https://github.com/unjs/giget/issues/104
