### PR TITLE
feat: support copying from local file protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ npx giget@latest https://api.github.com/repos/unjs/template/tarball/main
 
 # Clone from https URL (JSON)
 npx giget@latest https://raw.githubusercontent.com/unjs/giget/main/templates/unjs.json
+
+# Clone from a local directory using file protocol
+npx giget@latest file:///absolute/path/to/template
+
+# Clone from a local directory using file protocol and expand ~ to home directory
+npx giget@latest file:~/Documents/my-template
 ```
 
 ## Template Registry

--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ npx giget@latest https://raw.githubusercontent.com/unjs/giget/main/templates/unj
 
 # Clone from a local directory using file protocol
 npx giget@latest file:///absolute/path/to/template
-
-# Clone from a local directory using file protocol and expand ~ to home directory
-npx giget@latest file:~/Documents/my-template
 ```
 
 ## Template Registry

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { defineCommand, runMain } from "citty";
 import { consola } from "consola";
 import pkg from "../package.json" assert { type: "json" };
-import { downloadTemplate } from "./giget";
+import { copyTemplate, downloadTemplate } from "./giget";
 import { startShell } from "./_utils";
 
 const mainCommand = defineCommand({
@@ -69,15 +69,25 @@ const mainCommand = defineCommand({
       process.env.DEBUG = process.env.DEBUG || "true";
     }
 
-    const r = await downloadTemplate(args.template, {
-      dir: args.dir,
-      force: args.force,
-      forceClean: args.forceClean,
-      offline: args.offline,
-      preferOffline: args.preferOffline,
-      auth: args.auth,
-      install: args.install,
-    });
+    const r = args.template.startsWith("file:")
+      ? await copyTemplate(args.template, {
+          dir: args.dir,
+          force: args.force,
+          forceClean: args.forceClean,
+          offline: args.offline,
+          preferOffline: args.preferOffline,
+          auth: args.auth,
+          install: args.install,
+        })
+      : await downloadTemplate(args.template, {
+          dir: args.dir,
+          force: args.force,
+          forceClean: args.forceClean,
+          offline: args.offline,
+          preferOffline: args.preferOffline,
+          auth: args.auth,
+          install: args.install,
+        });
 
     const _from = r.name || r.url;
     const _to = relative(process.cwd(), r.dir) || "./";

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -1,9 +1,10 @@
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, cp } from "node:fs/promises";
 import { existsSync, readdirSync } from "node:fs";
+import os from "node:os";
 // @ts-ignore
 import tarExtract from "tar/lib/extract.js";
 import type { ExtractOptions } from "tar";
-import { resolve, dirname } from "pathe";
+import { resolve, dirname, basename } from "pathe";
 import { defu } from "defu";
 import { installDependencies } from "nypm";
 import { cacheDirectory, download, debug, normalizeHeaders } from "./_utils";
@@ -161,6 +162,69 @@ export async function downloadTemplate(
     },
   });
   debug(`Extracted to ${extractPath} in ${Date.now() - s}ms`);
+
+  if (options.install) {
+    debug("Installing dependencies...");
+    await installDependencies({
+      cwd: extractPath,
+      silent: options.silent,
+    });
+  }
+
+  return {
+    ...template,
+    source,
+    dir: extractPath,
+  };
+}
+
+export async function copyTemplate(
+  input: string,
+  options: DownloadTemplateOptions = {},
+): Promise<DownloadTemplateResult> {
+  options = defu({ auth: process.env.GIGET_AUTH }, options);
+
+  const providerName = "file";
+  let source = input;
+  if (source.startsWith("file:~")) {
+    source = source.replace("file:~", "file://" + os.homedir());
+  }
+
+  const provider = options.providers?.[providerName] || providers[providerName];
+  if (!provider) {
+    throw new Error(`Unsupported provider: ${providerName}`);
+  }
+  const template = await Promise.resolve()
+    .then(() => provider(source, { auth: options.auth }))
+    .catch((error) => {
+      throw new Error(
+        `Failed to download template from ${providerName}: ${error.message}`,
+      );
+    });
+
+  if (!template) {
+    throw new Error(`Failed to resolve template from ${providerName}`);
+  }
+  template.name = (template.name || "template").replace(/[^\da-z-]/gi, "-");
+
+  const cwd = resolve(options.cwd || ".");
+  const extractPath = resolve(cwd, options.dir || basename(source));
+  const srcPath = decodeURIComponent(new URL(source).pathname);
+  if (options.forceClean) {
+    await rm(extractPath, { recursive: true, force: true });
+  }
+  if (
+    !options.force &&
+    existsSync(extractPath) &&
+    readdirSync(extractPath).length > 0
+  ) {
+    throw new Error(`Destination ${extractPath} already exists.`);
+  }
+  await mkdir(extractPath, { recursive: true });
+
+  const s = Date.now();
+  await cp(srcPath, extractPath, { recursive: true });
+  debug(`Copied to ${extractPath} in ${Date.now() - s}ms`);
 
   if (options.install) {
     debug("Installing dependencies...");

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -1,6 +1,5 @@
 import { mkdir, rm, cp } from "node:fs/promises";
 import { existsSync, readdirSync } from "node:fs";
-import os from "node:os";
 // @ts-ignore
 import tarExtract from "tar/lib/extract.js";
 import type { ExtractOptions } from "tar";
@@ -179,16 +178,12 @@ export async function downloadTemplate(
 }
 
 export async function copyTemplate(
-  input: string,
+  source: string,
   options: DownloadTemplateOptions = {},
 ): Promise<DownloadTemplateResult> {
   options = defu({ auth: process.env.GIGET_AUTH }, options);
 
   const providerName = "file";
-  let source = input;
-  if (source.startsWith("file:~")) {
-    source = source.replace("file:~", "file://" + os.homedir());
-  }
 
   const provider = options.providers?.[providerName] || providers[providerName];
   if (!provider) {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -60,6 +60,22 @@ const _httpJSON: TemplateProvider = async (input, options) => {
   return info;
 };
 
+const file: TemplateProvider = async (input, options) => {
+  const url = new URL(input);
+  const name: string = basename(url.pathname);
+
+  return {
+    name: `${name}-${url.href.slice(0, 8)}`,
+    version: "",
+    subdir: "",
+    tar: url.href,
+    defaultDir: name,
+    headers: {
+      Authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+    },
+  };
+};
+
 export const github: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input);
 
@@ -131,6 +147,7 @@ export const sourcehut: TemplateProvider = (input, options) => {
 export const providers: Record<string, TemplateProvider> = {
   http,
   https: http,
+  file,
   github,
   gh: github,
   gitlab,

--- a/test/getgit.test.ts
+++ b/test/getgit.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync } from "node:fs";
-import { rm, mkdir, writeFile } from "node:fs/promises";
-import { expect, it, describe, beforeAll } from "vitest";
+import { existsSync } from "node:fs";
+import { rm, mkdir, writeFile, rmdir } from "node:fs/promises";
+import { expect, it, describe, beforeAll, afterAll } from "vitest";
 import { resolve } from "pathe";
 import { downloadTemplate, copyTemplate } from "../src";
 
@@ -36,6 +36,10 @@ describe("copyTemplate (file protocol)", () => {
     await rm(tmpDir, { recursive: true, force: true });
     await mkdir(srcDir, { recursive: true });
     await writeFile(resolve(srcDir, "foo.txt"), "bar");
+  });
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    await rmdir(srcDir, { recursive: true });
   });
 
   it("copy a local directory", async () => {

--- a/test/getgit.test.ts
+++ b/test/getgit.test.ts
@@ -1,8 +1,8 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { rm, mkdir, writeFile } from "node:fs/promises";
 import { expect, it, describe, beforeAll } from "vitest";
 import { resolve } from "pathe";
-import { downloadTemplate } from "../src";
+import { downloadTemplate, copyTemplate } from "../src";
 
 describe("downloadTemplate", () => {
   beforeAll(async () => {
@@ -24,6 +24,32 @@ describe("downloadTemplate", () => {
     await writeFile(resolve(destinationDirectory, "test.txt"), "test");
     await expect(
       downloadTemplate("gh:unjs/template", { dir: destinationDirectory }),
+    ).rejects.toThrow("already exists");
+  });
+});
+
+describe("copyTemplate (file protocol)", () => {
+  const tmpDir = resolve(__dirname, ".tmp/copied");
+  const srcDir = resolve(__dirname, "fixtures/my-template");
+
+  beforeAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(resolve(srcDir, "foo.txt"), "bar");
+  });
+
+  it("copy a local directory", async () => {
+    const destDir = resolve(tmpDir, "copied");
+    const { dir } = await copyTemplate(`file:${srcDir}`, { dir: destDir });
+    expect(existsSync(resolve(dir, "foo.txt"))).toBe(true);
+  });
+
+  it("do not clone to exisiting dir", async () => {
+    const destDir = resolve(tmpDir, "existing");
+    await mkdir(destDir, { recursive: true });
+    await writeFile(resolve(destDir, "test.txt"), "test");
+    await expect(
+      copyTemplate(`file:${srcDir}`, { dir: destDir }),
     ).rejects.toThrow("already exists");
   });
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #109 

Support for the `file` protocol has been added.

- Templates can now be specified using `file:///path/to/dir`
- Tilde (`~`) expansion is also supported. However, since the standard `file://` format typically only supports absolute paths, a custom format `file:~/` is used to enable this feature.


Since the `file` protocol involves copying a directory rather than extracting a tarball, the processing logic and handling of options differ significantly from those in `downloadTemplate`. For this reason, we’ve separated the responsibilities and implemented it as a separate function.

If you believe it would be better to handle the `file` protocol as a branch within `downloadTemplate`, we’re happy to revise the implementation accordingly. We would appreciate your feedback.
