### PR TITLE
refactor: remove defu and pathe

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
   "dependencies": {
     "citty": "^0.1.6",
     "consola": "^3.4.2",
-    "defu": "^6.1.4",
     "node-fetch-native": "^1.6.7",
-    "nypm": "^0.6.1",
-    "pathe": "^2.0.3"
+    "nypm": "^0.6.1"
   },
   "devDependencies": {
     "@types/node": "^24.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,18 +19,12 @@ importers:
       consola:
         specifier: ^3.4.2
         version: 3.4.2
-      defu:
-        specifier: ^6.1.4
-        version: 6.1.4
       node-fetch-native:
         specifier: ^1.6.7
         version: 1.6.7
       nypm:
         specifier: ^0.6.1
         version: 0.6.1
-      pathe:
-        specifier: ^2.0.3
-        version: 2.0.3
     devDependencies:
       '@types/node':
         specifier: ^24.4.0

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -5,7 +5,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { promisify } from "node:util";
 import type { Agent } from "node:http";
-import { relative, resolve } from "pathe";
+import { relative, resolve } from "node:path";
 import { fetch } from "node-fetch-native/proxy";
 import type { GitInfo } from "./types";
 

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -1,10 +1,9 @@
 import { mkdir, rm } from "node:fs/promises";
 import { existsSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
 // @ts-ignore
 import tarExtract from "tar/lib/extract.js";
 import type { ExtractOptions } from "tar";
-import { resolve, dirname } from "pathe";
-import { defu } from "defu";
 import { installDependencies } from "nypm";
 import { cacheDirectory, download, debug, normalizeHeaders } from "./_utils";
 import { providers } from "./providers";
@@ -37,13 +36,8 @@ export async function downloadTemplate(
   input: string,
   options: DownloadTemplateOptions = {},
 ): Promise<DownloadTemplateResult> {
-  options = defu(
-    {
-      registry: process.env.GIGET_REGISTRY,
-      auth: process.env.GIGET_AUTH,
-    },
-    options,
-  );
+  options.registry = process.env.GIGET_REGISTRY ?? options.registry;
+  options.auth = process.env.GIGET_AUTH ?? options.auth;
 
   const registry =
     options.registry === false

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,4 +1,4 @@
-import { basename } from "pathe";
+import { basename } from "node:path";
 import type { TemplateInfo, TemplateProvider } from "./types";
 import { debug, parseGitURI, sendFetch } from "./_utils";
 

--- a/test/getgit.test.ts
+++ b/test/getgit.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { rm, mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { expect, it, describe, beforeAll } from "vitest";
-import { resolve } from "pathe";
 import { downloadTemplate } from "../src";
 
 describe("downloadTemplate", () => {


### PR DESCRIPTION
Part of https://github.com/unjs/giget/issues/236

This removes `defu` and `pathe` in the current codebase as I think the manual/native equivalents also work fine here.