### PR TITLE
Add Tangled as git provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Giget
 
-Giget is a zero-dependency CLI and programmatic API for downloading templates and git repositories. It supports GitHub, GitLab, Bitbucket, Sourcehut, and custom registries with offline caching via etags.
+Giget is a zero-dependency CLI and programmatic API for downloading templates and git repositories. It supports GitHub, GitLab, Bitbucket, Sourcehut, Tangled, and custom registries with offline caching via etags.
 
 ## Quick Reference
 
@@ -20,7 +20,7 @@ pnpm giget          # Run CLI from source (node ./src/cli.ts)
 src/
   index.ts        # Public exports (re-exports from giget.ts, types.ts, registry.ts)
   giget.ts        # Core: downloadTemplate() — resolves provider, downloads tarball, extracts
-  providers.ts    # Built-in providers: github, gitlab, bitbucket, sourcehut, http
+  providers.ts    # Built-in providers: github, gitlab, bitbucket, sourcehut, tangled, http
   registry.ts     # Template registry provider (fetches JSON from registry URL)
   types.ts        # Type definitions: GitInfo, TemplateInfo, TemplateProvider, options
   cli.ts          # CLI entry (uses citty). Bin: dist/cli.mjs
@@ -37,6 +37,7 @@ Providers are functions `(input, { auth }) => TemplateInfo | null`. Built-in pro
 - **GitLab** (`gitlab:`) — self-hosted via `GIGET_GITLAB_URL` env. Has `sec-fetch-mode` workaround header.
 - **Bitbucket** (`bitbucket:`) — standard tarball endpoint.
 - **Sourcehut** (`sourcehut:`) — uses `git.sr.ht` archive endpoint.
+- **Tangled** (`tangled:`) — AT Protocol-based forge. Supports DIDs as owners. Custom parsing (no `parseGitURI`). Archives have no top-level wrapper dir (`stripPrefix: false`). Self-hosted via `GIGET_TANGLED_URL` env.
 - **HTTP** (`http:`/`https:`) — direct tarball URL or JSON registry file.
 
 Git URI format: `org/repo[/subdir][#ref]` — parsed by `parseGitURI()` in `_utils.ts`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ✨ Zero dependency
 
-✨ Support popular git providers (GitHub, GitLab, Bitbucket, Sourcehut) out of the box.
+✨ Support popular git providers (GitHub, GitLab, Bitbucket, Sourcehut, Tangled) out of the box.
 
 ✨ Native [git clone provider](#git-clone-provider) with sparse checkout for subdirectories.
 
@@ -85,6 +85,12 @@ npx giget@latest bitbucket:unjs/template
 
 # Clone from sourcehut
 npx giget@latest sourcehut:pi0/unjs-template
+
+# Clone from tangled
+npx giget@latest tangled:username/repo
+
+# Clone from tangled using a DID
+npx giget@latest tangled:did:plc:abc123/repo
 
 # Clone using local git over HTTPS (see "Git Clone Provider" section)
 npx giget@latest git:unjs/template

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -151,7 +151,9 @@ export async function downloadTemplate(
     file: tarPath,
     cwd: extractPath,
     onReadEntry(entry) {
-      entry.path = entry.path.split("/").splice(1).join("/");
+      if (template.stripPrefix !== false) {
+        entry.path = entry.path.split("/").splice(1).join("/");
+      }
       if (subdir) {
         if (entry.path.startsWith(subdir + "/")) {
           // Rewrite path

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -146,6 +146,9 @@ export const tangled: TemplateProvider = (input, options) => {
   const rest = pathPart.slice(slashIndex + 1);
   const restParts = rest.split("/");
   const repo = restParts[0]!;
+  if (!repo) {
+    throw new Error(`Invalid Tangled URI: missing repository name in "${input}"`);
+  }
   const subdir = restParts.length > 1 ? "/" + restParts.slice(1).join("/") : "/";
 
   return {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -125,6 +125,37 @@ export const sourcehut: TemplateProvider = (input, options) => {
   };
 };
 
+export const tangled: TemplateProvider = (input, options) => {
+  const tangledURL = process.env.GIGET_TANGLED_URL || "https://tangled.org";
+
+  // DIDs (e.g. did:plc:abc123) contain colons that parseGitURI can't handle,
+  // so we parse the input ourselves.
+  const [pathPart = "", refPart] = input.split("#");
+  const ref = refPart || "main";
+  const slashIndex = pathPart.indexOf("/");
+  if (slashIndex === -1) {
+    throw new Error(`Invalid Tangled URI: ${input}`);
+  }
+
+  const owner = pathPart.slice(0, slashIndex);
+  const rest = pathPart.slice(slashIndex + 1);
+  const restParts = rest.split("/");
+  const repo = restParts[0]!;
+  const subdir = restParts.length > 1 ? "/" + restParts.slice(1).join("/") : "/";
+
+  return {
+    name: `${owner}-${repo}`.replace(/[:./]/g, "-"),
+    version: ref,
+    subdir,
+    headers: {
+      authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+    },
+    url: `${tangledURL}/${owner}/${repo}`,
+    tar: `${tangledURL}/${owner}/${repo}/archive/${ref}`,
+    stripPrefix: false,
+  };
+};
+
 export const providers: Record<string, TemplateProvider> = {
   http,
   https: http,
@@ -134,4 +165,5 @@ export const providers: Record<string, TemplateProvider> = {
   gitlab,
   bitbucket,
   sourcehut,
+  tangled,
 };

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -138,6 +138,11 @@ export const tangled: TemplateProvider = (input, options) => {
   }
 
   const owner = pathPart.slice(0, slashIndex);
+  if (!owner.startsWith("did:") && !owner.includes(".")) {
+    throw new Error(
+      `Invalid Tangled owner "${owner}": must be a domain (e.g. alice.tangled.org) or a DID (e.g. did:plc:abc123, did:web:example.org)`,
+    );
+  }
   const rest = pathPart.slice(slashIndex + 1);
   const restParts = rest.split("/");
   const repo = restParts[0]!;

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -125,6 +125,14 @@ export const sourcehut: TemplateProvider = (input, options) => {
   };
 };
 
+// Tangled (https://tangled.org) is an AT Protocol-based git forge. Owners are
+// either domains (e.g. `alice.tangled.org`) or DIDs (e.g. `did:plc:abc123`, `did:web:example.org`).
+//
+// Accepted input format: `{owner}/{repo}[/{subdir}][#{ref}]`
+//   - `alice.example.org/my-repo`
+//   - `did:plc:abc123/my-repo#dev`
+//
+// Self-hosted instances are supported via the `GIGET_TANGLED_URL` env var.
 export const tangled: TemplateProvider = (input, options) => {
   const tangledURL = process.env.GIGET_TANGLED_URL || "https://tangled.org";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface TemplateInfo {
   url?: string;
   defaultDir?: string;
   headers?: Record<string, string | undefined>;
+  // Set to `false` when the tar archive's entries are not wrapped in a
+  // top-level directory (like with Tangled archives).
   stripPrefix?: boolean;
 
   // Added by giget

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { Readable } from "node:stream";
 
 export interface GitInfo {
-  provider: "github" | "gitlab" | "bitbucket" | "sourcehut";
+  provider: "github" | "gitlab" | "bitbucket" | "sourcehut" | "tangled";
   repo: string;
   subdir: string;
   ref: string;
@@ -17,6 +17,7 @@ export interface TemplateInfo {
   url?: string;
   defaultDir?: string;
   headers?: Record<string, string | undefined>;
+  stripPrefix?: boolean;
 
   // Added by giget
   source?: never;


### PR DESCRIPTION
Adds support for [Tangled](https://tangled.org) as a provider.

I've had to use customised URI parsing to support both usernames and DIDs (e.g. `did:plc:abc123def456` or `did:web:example.org`, as well as `tangled.org` or `byjp.me`) as repo owners, as both are supported by Tangled.

I also added a `stripPrefix` option to `TemplateInfo` since Tangled archives don't have a top-level wrapper directory.

resolves #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tangled added as a built-in provider with DID-based owners and tangled: URL formats; optional custom Tangled API URL for self-hosting.

* **Documentation**
  * README and provider docs updated with Tangled usage and CLI examples.

* **Bug Fixes**
  * Archive extraction now respects the stripPrefix setting so top-level directory behavior is preserved when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->