### PR TITLE
feat: support ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npx giget@latest <template> [<dir>] [...options]
 - `--cwd`: Set the current working directory to resolve dirs relative to it.
 - `--auth`: Custom Authorization token to use for downloading template. (Can be overridden with `GIGET_AUTH` environment variable).
 - `--install`: Install dependencies after cloning using [unjs/nypm](https://github.com/unjs/nypm).
+- `--ignore`: Comma separated glob patterns of files to ignore (skip extracting), e.g. `--ignore pnpm-lock.yaml,*.md`.
 
 ### Examples
 
@@ -162,6 +163,7 @@ const { source, dir } = await downloadTemplate("github:unjs/template");
   - `registry`: (string or false) Set to `false` to disable registry. Set to a URL string (without trailing slash) for custom registry. (Can be overridden with `GIGET_REGISTRY` environment variable).
   - `cwd`: (string) Current working directory to resolve dirs relative to it.
   - `auth`: (string) Custom Authorization token to use for downloading template. (Can be overridden with `GIGET_AUTH` environment variable).
+  - `ignore`: (array or function) Ignore files when extracting. Either an array of glob patterns of files to skip, matched with [`path.matchesGlob`](https://nodejs.org/api/path.html#pathmatchesglobpath-pattern) (`ignore: ["pnpm-lock.yaml", "*.md"]`), or a callback receiving the relative path of each entry (after `subdir` is applied) that returns `true` to skip it, or `false` to keep it (`ignore: (path) => path === "pnpm-lock.yaml"`). Patterns require Node.js >= v22.5.0 or v20.17.0.
 
 **Return value:**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,11 @@ const mainCommand = defineCommand({
       type: "boolean",
       description: "Install dependencies after cloning",
     },
+    ignore: {
+      type: "string",
+      description:
+        "Comma separated glob patterns of files to ignore (skip extracting). e.g. `--ignore pnpm-lock.yaml,*.md`",
+    },
     verbose: {
       type: "boolean",
       description: "Show verbose debugging info",
@@ -65,6 +70,11 @@ const mainCommand = defineCommand({
     if (args.verbose) {
       process.env.DEBUG = process.env.DEBUG || "true";
     }
+
+    const ignore = (args.ignore || "")
+      .split(",")
+      .map((pattern) => pattern.trim())
+      .filter(Boolean);
 
     let r: Awaited<ReturnType<typeof downloadTemplate>>;
     try {
@@ -76,6 +86,7 @@ const mainCommand = defineCommand({
         preferOffline: args.preferOffline,
         auth: args.auth,
         install: args.install,
+        ignore: ignore.length > 0 ? ignore : undefined,
       });
     } catch (error) {
       if (args.verbose) {

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -25,6 +25,24 @@ export interface DownloadTemplateOptions {
   auth?: string;
   install?: boolean | InstallOptions;
   silent?: boolean;
+  /**
+   * Ignore files when extracting the template.
+   *
+   * Can be either:
+   * - An array of glob patterns of files to ignore (skip extracting), matched
+   *   with [`path.matchesGlob`](https://nodejs.org/api/path.html#pathmatchesglobpath-pattern)
+   *   (Node.js >= v22.5.0 or v20.17.0).
+   * - A callback receiving the relative path of each entry (after `subdir` is
+   *   applied) that returns `true` to skip the entry, or `false` to keep it.
+   *
+   * @example
+   * // Ignore lockfiles via patterns
+   * ignore: ["pnpm-lock.yaml", "*.lock"]
+   * @example
+   * // Ignore lockfiles via callback
+   * ignore: (path) => /(?:^|\/)(?:pnpm-lock\.yaml|package-lock\.json|yarn\.lock)$/.test(path)
+   */
+  ignore?: ((path: string) => boolean) | string[];
 }
 
 const sourceProtoRe = /^([\w+-.]+):/;
@@ -34,10 +52,32 @@ export type DownloadTemplateResult = Omit<TemplateInfo, "dir" | "source"> & {
   source: string;
 };
 
+function resolveIgnore(
+  ignore: DownloadTemplateOptions["ignore"],
+): ((path: string) => boolean) | undefined {
+  if (!ignore) {
+    return undefined;
+  }
+  if (typeof ignore === "function") {
+    return ignore;
+  }
+  // Use `process.getBuiltinModule` for feature detection since a static
+  // `import { matchesGlob }` fails to link on Node.js versions without it.
+  const matchesGlob = globalThis.process.getBuiltinModule?.("node:path")?.matchesGlob;
+  if (typeof matchesGlob !== "function") {
+    throw new TypeError(
+      "Ignore patterns require `path.matchesGlob` which is supported in Node.js v22.5.0, v20.17.0 or later.",
+    );
+  }
+  return (path) => ignore.some((pattern) => matchesGlob(path, pattern));
+}
+
 export async function downloadTemplate(
   input: string,
   options: DownloadTemplateOptions = {},
 ): Promise<DownloadTemplateResult> {
+  const ignore = resolveIgnore(options.ignore);
+
   options.registry = process.env.GIGET_REGISTRY ?? options.registry;
   options.auth = process.env.GIGET_AUTH ?? options.auth;
 
@@ -160,6 +200,10 @@ export async function downloadTemplate(
           // Skip
           entry.path = "";
         }
+      }
+      if (ignore && entry.path && ignore(entry.path.replace(/^\//, ""))) {
+        // Skip ignored entries
+        entry.path = "";
       }
     },
   });

--- a/test/getgit.test.ts
+++ b/test/getgit.test.ts
@@ -106,6 +106,34 @@ describe("downloadTemplate", () => {
     expect(existsSync(resolve(dir, "index.ts"))).toBe(true);
   });
 
+  it("clone unjs/template with ignore callback", async () => {
+    const destinationDirectory = resolve(__dirname, ".tmp/cloned-filtered");
+    const seen: string[] = [];
+    const { dir } = await downloadTemplate("gh:unjs/template", {
+      dir: destinationDirectory,
+      preferOffline,
+      ignore: (path) => {
+        seen.push(path);
+        return path === "package.json";
+      },
+    });
+    expect(seen).toContain("package.json");
+    expect(existsSync(resolve(dir, "package.json"))).toBe(false);
+    expect(existsSync(resolve(dir, "README.md"))).toBe(true);
+  });
+
+  it("clone unjs/template with ignore patterns", async () => {
+    const destinationDirectory = resolve(__dirname, ".tmp/cloned-ignored");
+    const { dir } = await downloadTemplate("gh:unjs/template", {
+      dir: destinationDirectory,
+      preferOffline,
+      ignore: ["*.md", "renovate.json"],
+    });
+    expect(existsSync(resolve(dir, "README.md"))).toBe(false);
+    expect(existsSync(resolve(dir, "renovate.json"))).toBe(false);
+    expect(existsSync(resolve(dir, "package.json"))).toBe(true);
+  });
+
   it("do not clone to exisiting dir", async () => {
     const destinationDirectory = resolve(__dirname, ".tmp/exisiting");
     await mkdir(destinationDirectory).catch(() => {});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--ignore` CLI option to skip files during template extraction using comma-separated glob patterns.
  * Added programmatic `ignore` option supporting glob patterns or custom predicate functions for filtering extraction entries.

* **Tests**
  * Added test cases verifying ignore functionality with both callback-based and glob pattern approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->