### PR TITLE
fix: use token auth for GitHub PAT downloads

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -69,7 +69,7 @@ export const github: TemplateProvider = (input, options) => {
     version: parsed.ref,
     subdir: parsed.subdir,
     headers: {
-      Authorization: options.auth ? `Bearer ${options.auth}` : undefined,
+      Authorization: githubAuthorization(options.auth),
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
     },
@@ -79,6 +79,14 @@ export const github: TemplateProvider = (input, options) => {
     tar: `${githubAPIURL}/repos/${parsed.repo}/tarball/${parsed.ref}`,
   };
 };
+
+export function githubAuthorization(auth?: string) {
+  if (!auth) {
+    return undefined;
+  }
+
+  return `${auth.startsWith("eyJ") ? "Bearer" : "token"} ${auth}`;
+}
 
 export const gitlab: TemplateProvider = (input, options) => {
   const parsed = parseGitURI(input, { expandRepo: true });

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -22,6 +22,22 @@ describe("github provider", () => {
     const result = github("org/repo", { auth: "" }) as TemplateInfo;
     expect(result.headers?.Authorization).toBeUndefined();
   });
+
+  it("respects GIGET_GITHUB_URL", () => {
+    const prev = process.env.GIGET_GITHUB_URL;
+    process.env.GIGET_GITHUB_URL = "https://git.example.com/api";
+    try {
+      const result = github("org/repo", { auth: "" }) as TemplateInfo;
+      expect(result.url).toBe("https://git.example.com/api/org/repo/tree/main/");
+      expect(result.tar).toBe("https://git.example.com/api/repos/org/repo/tarball/main");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.GIGET_GITHUB_URL;
+      } else {
+        process.env.GIGET_GITHUB_URL = prev;
+      }
+    }
+  });
 });
 
 describe("gitlab provider", () => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1,6 +1,28 @@
 import { expect, it, describe } from "vitest";
-import { gitlab } from "../src/providers.ts";
+import { github, gitlab } from "../src/providers.ts";
 import type { TemplateInfo } from "../src/types.ts";
+
+describe("github provider", () => {
+  it("uses token auth for fine-grained personal access tokens", () => {
+    const result = github("org/repo", { auth: "github_pat_123" }) as TemplateInfo;
+    expect(result.headers?.Authorization).toBe("token github_pat_123");
+  });
+
+  it("uses token auth for classic personal access tokens", () => {
+    const result = github("org/repo", { auth: "ghp_123" }) as TemplateInfo;
+    expect(result.headers?.Authorization).toBe("token ghp_123");
+  });
+
+  it("keeps bearer auth for JWT tokens", () => {
+    const result = github("org/repo", { auth: "eyJ123" }) as TemplateInfo;
+    expect(result.headers?.Authorization).toBe("Bearer eyJ123");
+  });
+
+  it("does not set authorization without auth", () => {
+    const result = github("org/repo", { auth: "" }) as TemplateInfo;
+    expect(result.headers?.Authorization).toBeUndefined();
+  });
+});
 
 describe("gitlab provider", () => {
   const opts = { auth: "" };


### PR DESCRIPTION
Fixes #263.

This is a smaller follow-up to #265, limited to the GitHub provider authorization header for archive downloads.

GitHub tarball downloads can reject fine-grained and classic personal access tokens when they are sent with the Bearer scheme. This keeps Bearer for JWT-style tokens and uses the token scheme for other GitHub tokens, including PATs.

Verification:

- `pnpm install --ignore-workspace`
- `pnpm --ignore-workspace exec vitest run test/providers.test.ts`
- `pnpm --ignore-workspace lint`
- `pnpm --ignore-workspace test:types`
- `pnpm --ignore-workspace build`
- `git diff --check`

I also attempted the full `pnpm --ignore-workspace exec vitest run --coverage`; one network-backed custom-provider archive test failed with `TAR_BAD_ARCHIVE` while the targeted provider regression test and static checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication header handling, including correct formatting for JWT-style and personal access tokens.
  * Ensured the header name casing is consistent and omitted the auth header when no credentials are provided.
  * Respected the configured GitHub base URL override for generated endpoints.
* **Tests**
  * Added/expanded test coverage for GitHub provider auth formatting across token types and URL override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->