### PR TITLE
fix(http): derive the template name from a digest of the whole URL

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,7 +1,16 @@
+import { createHash } from "node:crypto";
 import { basename } from "pathe";
 import type { TemplateInfo, TemplateProvider } from "./types.ts";
 import { debug, parseGitURI, sendFetch } from "./_utils.ts";
 import { git } from "./git.ts";
+
+// The name is used as the cache directory for the downloaded tarball, so it has
+// to distinguish two URLs that share a basename (e.g. `a.com/x/tpl.tar.gz` and
+// `b.com/y/tpl.tar.gz`). Hex digits survive the `[^\da-z-]` sanitization applied
+// to `name` in `downloadTemplate`.
+function _urlDigest(url: string): string {
+  return createHash("sha256").update(url).digest("hex").slice(0, 8);
+}
 
 export const http: TemplateProvider = async (input, options) => {
   if (input.endsWith(".json")) {
@@ -32,7 +41,7 @@ export const http: TemplateProvider = async (input, options) => {
   }
 
   return {
-    name: `${name}-${url.href.slice(0, 8)}`,
+    name: `${name}-${_urlDigest(url.href)}`,
     version: "",
     subdir: "",
     tar: url.href,

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1,12 +1,21 @@
-import { expect, it, describe } from "vitest";
+import { expect, it, describe, vi } from "vitest";
 import { gitlab, http } from "../src/providers.ts";
 import type { TemplateInfo } from "../src/types.ts";
+
+// The `http` provider sends a best-effort HEAD request before deriving the
+// name. Stub it so the tests below stay offline and deterministic: a response
+// that is neither JSON nor carries a `content-disposition` filename leaves the
+// name derived from the URL, which is what is under test here.
+vi.mock("../src/_utils.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/_utils.ts")>()),
+  sendFetch: vi.fn(
+    async () => new Response("", { headers: { "content-type": "application/gzip" } }),
+  ),
+}));
 
 describe("http provider", () => {
   const opts = { auth: "" };
 
-  // The HEAD request is best effort and its failure is swallowed, so these run
-  // offline; only the name derivation is under test.
   it("derives distinct names for same-basename URLs on different hosts", async () => {
     const a = (await http("https://a.example.com/x/template.tar.gz", opts)) as TemplateInfo;
     const b = (await http("https://b.example.com/y/template.tar.gz", opts)) as TemplateInfo;

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1,6 +1,32 @@
 import { expect, it, describe } from "vitest";
-import { gitlab } from "../src/providers.ts";
+import { gitlab, http } from "../src/providers.ts";
 import type { TemplateInfo } from "../src/types.ts";
+
+describe("http provider", () => {
+  const opts = { auth: "" };
+
+  // The HEAD request is best effort and its failure is swallowed, so these run
+  // offline; only the name derivation is under test.
+  it("derives distinct names for same-basename URLs on different hosts", async () => {
+    const a = (await http("https://a.example.com/x/template.tar.gz", opts)) as TemplateInfo;
+    const b = (await http("https://b.example.com/y/template.tar.gz", opts)) as TemplateInfo;
+    expect(a.name).not.toBe(b.name);
+  });
+
+  it("derives distinct names for same-basename URLs on the same host", async () => {
+    const a = (await http("https://example.com/x/template.tar.gz", opts)) as TemplateInfo;
+    const b = (await http("https://example.com/y/template.tar.gz", opts)) as TemplateInfo;
+    expect(a.name).not.toBe(b.name);
+  });
+
+  it("derives a stable, sanitization-safe name", async () => {
+    const first = (await http("https://example.com/x/template.tar.gz", opts)) as TemplateInfo;
+    const second = (await http("https://example.com/x/template.tar.gz", opts)) as TemplateInfo;
+    expect(first.name).toBe(second.name);
+    // `downloadTemplate` strips anything outside `[\da-z-]` from the name.
+    expect(first.name.replace("template.tar.gz-", "")).toMatch(/^[\da-f]{8}$/);
+  });
+});
 
 describe("gitlab provider", () => {
   const opts = { auth: "" };


### PR DESCRIPTION
## Problem

The `http` provider names a template `${basename}-${url.href.slice(0, 8)}`:

https://github.com/unjs/giget/blob/main/src/providers.ts#L35

For an absolute URL the first eight characters are always the scheme and separator — `https://` — so the suffix carries no information about which URL it came from. Two tarballs that share a basename get the same name:

```js
import { http } from "giget";

await http("https://a.example.com/x/template.tar.gz", {}); // name: template.tar.gz-https://
await http("https://b.example.com/y/template.tar.gz", {}); // name: template.tar.gz-https://
```

That matters because `downloadTemplate` derives the cache path from the name:

```js
const temporaryDirectory = resolve(cacheDirectory(), providerName, template.name);
const tarPath = resolve(temporaryDirectory, (template.version || template.name) + ".tar.gz");
```

`version` is `""` for this provider, so both URLs resolve to the same `tarPath`. Since the etag check in `download()` is per-file, the second URL is compared against the *first* URL's etag — and with `--offline` / `--prefer-offline` (or when the network call fails and the cached copy is used) the wrong template is extracted outright.

The suffix is also lost to sanitization: `downloadTemplate` strips everything outside `[\da-z-]`, turning `https://` into `https---` for every http-provider template.

## Fix

Hash the full URL and keep eight hex characters. Hex digits survive the sanitization, and the name stays stable for a given URL, so existing caches keep working per-URL.

## Test plan

- `test/providers.test.ts`: three cases covering different hosts, different paths on the same host, and name stability + the character class. All three fail on `main` (`expected 'https://' to match /^[\da-f]{8}$/`) and pass with the fix.
- `pnpm exec vitest run test/providers.test.ts test/utils.test.ts test/git.test.ts` — 51 passed.
- `pnpm lint` (oxlint + oxfmt) and `pnpm test:types` — clean.
- Full `vitest run`: 60 passed, 1 failed — `getgit.test.ts > clone unjs/template using custom provider that returns stream` fails with `TAR_BAD_ARCHIVE` on unmodified `main` here too, so it is a pre-existing network-backed failure and not from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP template caching to generate unique, consistent names from complete URLs.
  * Prevented naming conflicts between URLs that share the same beginning.
  * Ensured generated cache names use safe eight-character hexadecimal identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->