### PR TITLE
feat: force respect HTTP_PROXY in Node.js

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -63,6 +63,22 @@ export function debug(...args: unknown[]) {
   }
 }
 
+export function initEnvProxy(options?: boolean | { force?: boolean }) {
+  const force = typeof options === "boolean" ? options : options?.force;
+  if (
+    process.env.NODE_USE_ENV_PROXY === undefined &&
+    (force ||
+      process.env.HTTP_PROXY ||
+      process.env.HTTPS_PROXY ||
+      process.env.http_proxy ||
+      process.env.https_proxy ||
+      process.env.ALL_PROXY ||
+      process.env.all_proxy)
+  ) {
+    process.env.NODE_USE_ENV_PROXY = "1";
+  }
+}
+
 interface InternalFetchOptions extends Omit<RequestInit, "headers"> {
   headers?: Record<string, string | undefined>;
   agent?: Agent;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,9 @@ import { relative } from "pathe";
 import { defineCommand, runMain } from "citty";
 import pkg from "../package.json" with { type: "json" };
 import { downloadTemplate } from "./giget.ts";
-import { startShell } from "./_utils.ts";
+import { initEnvProxy, startShell } from "./_utils.ts";
+
+initEnvProxy();
 
 const mainCommand = defineCommand({
   meta: {

--- a/src/giget.ts
+++ b/src/giget.ts
@@ -5,7 +5,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { resolve, dirname } from "pathe";
 import type { installDependencies } from "nypm";
-import { cacheDirectory, download, debug, normalizeHeaders } from "./_utils.ts";
+import { cacheDirectory, download, debug, normalizeHeaders, initEnvProxy } from "./_utils.ts";
 import { providers } from "./providers.ts";
 import { registryProvider } from "./registry.ts";
 import type { TemplateInfo, TemplateProvider } from "./types.ts";
@@ -76,6 +76,8 @@ export async function downloadTemplate(
   input: string,
   options: DownloadTemplateOptions = {},
 ): Promise<DownloadTemplateResult> {
+  initEnvProxy();
+
   const ignore = resolveIgnore(options.ignore);
 
   options.registry = process.env.GIGET_REGISTRY ?? options.registry;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./giget.ts";
 export * from "./types.ts";
 export { registryProvider } from "./registry.ts";
-export { startShell } from "./_utils.ts";
+export { initEnvProxy, startShell } from "./_utils.ts";

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
-import { expect, it, describe } from "vitest";
-import { parseGitURI } from "../src/_utils.ts";
+import { expect, it, describe, beforeEach, afterEach } from "vitest";
+import { parseGitURI, initEnvProxy } from "../src/_utils.ts";
 
 describe("parseGitURI", () => {
   const defaults = { repo: "org/repo", subdir: "/", ref: "main" };
@@ -115,4 +115,87 @@ describe("parseGitURI with expandRepo", () => {
       });
     });
   }
+});
+
+describe("initEnvProxy", () => {
+  const envKeys = [
+    "NODE_USE_ENV_PROXY",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+  ] as const;
+
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (originalEnv[key] !== undefined) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("does not set NODE_USE_ENV_PROXY when no proxy variables exist", () => {
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBeUndefined();
+  });
+
+  it("sets NODE_USE_ENV_PROXY to 1 when HTTP_PROXY is present", () => {
+    process.env.HTTP_PROXY = "http://proxy.example.com";
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("sets NODE_USE_ENV_PROXY to 1 when HTTPS_PROXY is present", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com";
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("sets NODE_USE_ENV_PROXY to 1 when http_proxy is present", () => {
+    process.env.http_proxy = "http://proxy.example.com";
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("sets NODE_USE_ENV_PROXY to 1 when https_proxy is present", () => {
+    process.env.https_proxy = "http://proxy.example.com";
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("sets NODE_USE_ENV_PROXY to 1 when all_proxy is present", () => {
+    process.env.all_proxy = "http://proxy.example.com";
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("does not overwrite existing NODE_USE_ENV_PROXY value", () => {
+    process.env.NODE_USE_ENV_PROXY = "0";
+    process.env.HTTP_PROXY = "http://proxy.example.com";
+    initEnvProxy();
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("0");
+  });
+
+  it("forces NODE_USE_ENV_PROXY when force is passed as boolean true", () => {
+    initEnvProxy(true);
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("forces NODE_USE_ENV_PROXY when force option is passed in object", () => {
+    initEnvProxy({ force: true });
+    expect(process.env.NODE_USE_ENV_PROXY).toBe("1");
+  });
 });


### PR DESCRIPTION
Resolves #251

### Context & Solution

In Node.js (>=20.19.0 / >=22.14.0 / >=24.13.0), built-in proxy support for `fetch()` requires the `NODE_USE_ENV_PROXY=1` environment variable. While runtimes like Deno and Bun respect `HTTP_PROXY` by default, Node requires this flag to be enabled.

This PR adds:
- `initEnvProxy(options?)`: Exported helper in `src/_utils.ts` and re-exported from the package root. When standard proxy environment variables are present (`HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, `https_proxy`, `ALL_PROXY`, `all_proxy`) and `NODE_USE_ENV_PROXY` is not explicitly configured, it sets `process.env.NODE_USE_ENV_PROXY = "1"`. An optional `force: true` parameter is also supported.
- Invokes `initEnvProxy()` in `src/cli.ts` so the `giget` CLI automatically respects proxy environments.
- Invokes `initEnvProxy()` in `downloadTemplate()` in `src/giget.ts`.
- Comprehensive unit tests in `test/utils.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic proxy environment support for command-line operations and template downloads.
  * Proxy support is enabled when standard proxy environment variables are detected.
  * Added an option to force proxy support when needed.
  * Exposed proxy initialization for programmatic use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->